### PR TITLE
Expressly states web application framework Express 3.5.1 as dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"dependencies" : {
 		"node-schedule": "*",
 		"cheerio": "*",
-		"express": "*",
+		"express": "3.5.1",
 		"socket.io": "*", 
 		"async": "*",
 		"ejs": "*"


### PR DESCRIPTION
Express 4 will break the application.

Change-Id: Ic2fd863f5844c196d75ab1679f0ab64c15d61d70
