### PR TITLE
Updates version range for embedded javascript templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
 	"version": "0.1.2",
 	"author": "Andrew Lobos, based on an idea/concept by Alex Lagunas",
 	"description": "Link and file sharing web application",
-	
-	"contributors": [ 
+
+	"contributors": [
 	    {
 	      "name": "Andrew Lobos",
 	      "email": "andrew@lobos.me"
@@ -12,11 +12,11 @@
 	    {
 	      "name": "Ben Thomas",
 	      "email": "benjamin@thomasnetwork.net"
-	    }, 
+	    },
 	    {
 	      "name": "Alex Lagunas",
 	      "email": "alex@pennmanor.net"
-	    } 
+	    }
 
 	],
 	"dependencies" : {
@@ -24,8 +24,8 @@
 		"cheerio": "0.15.0",
 		"express": "4.0.0",
 		"body-parser": "1.0.2",
-		"socket.io": "0.9.16", 
+		"socket.io": "0.9.16",
 		"async": "0.7.0",
-		"ejs": "1.0.0"
+		"ejs": ">= 2.5.5"
 	}
 }


### PR DESCRIPTION
Due to vulnerability have ejs be at minimum 2.5.5.